### PR TITLE
Add Google Cloud CLI install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -71,6 +71,13 @@ else
   echo "⚠️  Azure Functions Core Tools install script not found or not executable"
 fi
 
+# Google Cloud CLI install
+if [[ -x "$DOTFILES_DIR/install/google-cloud-cli.sh" ]]; then
+  "$DOTFILES_DIR/install/google-cloud-cli.sh"
+else
+  echo "⚠️  Google Cloud CLI install script not found or not executable"
+fi
+
 # Add more install scripts below
 # "$DOTFILES_DIR/install/neovim.sh"
 # "$DOTFILES_DIR/install/tmux.sh"

--- a/install/google-cloud-cli.sh
+++ b/install/google-cloud-cli.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "📦 Installing Google Cloud CLI..."
+
+# Install prerequisites
+echo "📋 Installing prerequisites..."
+sudo apt-get update
+sudo apt-get install -y apt-transport-https ca-certificates gnupg
+
+# Add the Google Cloud CLI distribution URI as a package source
+echo "🌐 Adding Google Cloud CLI package source..."
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+  | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
+
+# Import the Google Cloud public key
+echo "🔑 Importing Google Cloud public key..."
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+  | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+
+# Update and install the Google Cloud CLI
+echo "🔄 Updating package list..."
+sudo apt-get update
+
+echo "⬇️  Installing Google Cloud CLI..."
+sudo apt-get install -y google-cloud-cli
+
+# Verify installation
+echo "✅ Google Cloud CLI installed. Version:"
+gcloud version


### PR DESCRIPTION
## Summary
- add script to install Google Cloud CLI via apt repo
- invoke Google Cloud CLI installer from main setup script

## Testing
- `shellcheck install/google-cloud-cli.sh` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*
- `sudo apt-get install -y shellcheck` *(fails: unable to locate package)*
- `bash -n install/google-cloud-cli.sh`

------
https://chatgpt.com/codex/tasks/task_e_68af34406f7c832e99cb26f0f39c6741