### PR TITLE
feat: add github cli install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -78,6 +78,13 @@ else
   echo "⚠️  Google Cloud CLI install script not found or not executable"
 fi
 
+# GitHub CLI install
+if [[ -x "$DOTFILES_DIR/install/github-cli.sh" ]]; then
+  "$DOTFILES_DIR/install/github-cli.sh"
+else
+  echo "⚠️  GitHub CLI install script not found or not executable"
+fi
+
 # Add more install scripts below
 # "$DOTFILES_DIR/install/neovim.sh"
 # "$DOTFILES_DIR/install/tmux.sh"

--- a/install/github-cli.sh
+++ b/install/github-cli.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "📦 Installing GitHub CLI..."
+
+# Remove old configuration if it exists
+echo "🔄 Cleaning old GitHub CLI configuration..."
+sudo rm -f /etc/apt/sources.list.d/github-cli.list
+sudo rm -f /usr/share/keyrings/githubcli-archive-keyring.gpg
+
+# Add the GitHub CLI GPG key
+echo "🔑 Adding GitHub CLI GPG key..."
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
+  sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg >/dev/null
+sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+
+# Add the GitHub CLI apt repository
+echo "📝 Adding GitHub CLI apt repository..."
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | \
+  sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+
+# Update and install
+echo "🔄 Updating package list..."
+sudo apt update
+
+echo "⬇️  Installing GitHub CLI..."
+sudo apt install -y gh
+
+# Verify installation
+echo "✅ GitHub CLI installed. Version:"
+gh --version


### PR DESCRIPTION
## Summary
- add script to install GitHub CLI via apt on Ubuntu
- integrate GitHub CLI installer into main install script

## Testing
- `bash install/github-cli.sh` *(fails: The requested URL returned error: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68af76ba0570832eae5fbcc4c0004707