### PR TITLE
Add install scripts for AI development tools

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,6 +85,27 @@ else
   echo "⚠️  GitHub CLI install script not found or not executable"
 fi
 
+# Claude Code install
+if [[ -x "$DOTFILES_DIR/install/claude-code.sh" ]]; then
+  "$DOTFILES_DIR/install/claude-code.sh"
+else
+  echo "⚠️  Claude Code install script not found or not executable"
+fi
+
+# Codex CLI install
+if [[ -x "$DOTFILES_DIR/install/codex-cli.sh" ]]; then
+  "$DOTFILES_DIR/install/codex-cli.sh"
+else
+  echo "⚠️  Codex CLI install script not found or not executable"
+fi
+
+# OpenCode.ai (SST) install
+if [[ -x "$DOTFILES_DIR/install/opencode-ai.sh" ]]; then
+  "$DOTFILES_DIR/install/opencode-ai.sh"
+else
+  echo "⚠️  OpenCode.ai (SST) install script not found or not executable"
+fi
+
 # Add more install scripts below
 # "$DOTFILES_DIR/install/neovim.sh"
 # "$DOTFILES_DIR/install/tmux.sh"

--- a/install/claude-code.sh
+++ b/install/claude-code.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "📦 Installing Claude Code..."
+
+npm install -g claude-code
+
+echo "✅ Claude Code installed. Version:"
+claude --version

--- a/install/codex-cli.sh
+++ b/install/codex-cli.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "📦 Installing Codex CLI..."
+
+npm install -g codex-cli
+
+echo "✅ Codex CLI installed. Version:"
+codex --version

--- a/install/opencode-ai.sh
+++ b/install/opencode-ai.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "📦 Installing OpenCode.ai (SST)..."
+
+npm install -g opencode
+
+echo "✅ OpenCode CLI installed. Version:"
+opencode --version


### PR DESCRIPTION
## Summary
- add dedicated install scripts for Claude Code, Codex CLI, and OpenCode.ai (SST)
- invoke new scripts from main installer

## Testing
- `bash -n install/claude-code.sh install/codex-cli.sh install/opencode-ai.sh install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b06477fd90832eb778e7399a8460f1